### PR TITLE
Fix broken link to styling notebook

### DIFF
--- a/notebooks/07-container-exercises.ipynb
+++ b/notebooks/07-container-exercises.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Container exercises\n",
     "\n",
-    "Earlier notebooks listed the container widgets in ipywidgets and how the widgets contained in them are laid out. As a reminder, the contents of the container are its `children`, a tuple of widgets. The distribution and alignment of the children are determined by the flex-box properties of the `layout` described in [Widget Styling](Widget-Styling.ipynb#The-Flexbox-layout).\n",
+    "Earlier notebooks listed the container widgets in ipywidgets and how the widgets contained in them are laid out. As a reminder, the contents of the container are its `children`, a tuple of widgets. The distribution and alignment of the children are determined by the flex-box properties of the `layout` described in [Widget Styling](06-Widget-Styling.ipynb#The-Flexbox-layout).\n",
     "\n",
     "This set of exercises leads up to a password generator widget that will be completed after discussing widget events. The generator allows the user to set the length of the password, choose a set of special characters to include, and decide whether to include any digits. \n",
     "\n",

--- a/notebooks/07-container-exercises.ipynb
+++ b/notebooks/07-container-exercises.ipynb
@@ -40,7 +40,7 @@
     "\n",
     "![final layout of widgets](images/container-exercises1-final-layout.png)\n",
     "\n",
-    "You may need to look back at the [styling notebook](04-Widget_Styling.ipynb)."
+    "You may need to look back at the [styling notebook](06-Widget_Styling.ipynb)."
    ]
   },
   {


### PR DESCRIPTION
Link in Notebook 7 (container exercises) was to `04-Widget_Styling.ipynb`, should be `06-Widget_Styling.ipynb`